### PR TITLE
Fixed lux calculation

### DIFF
--- a/bh1750.js
+++ b/bh1750.js
@@ -26,7 +26,11 @@ BH1750.prototype.readLight = function (cb) {
     this.wire.readBytes(this.options.command, this.options.length, function (err, res) {
         var hi = res.readUInt8(0);
         var lo = res.readUInt8(1);
-        cb.call(self, ((hi << 8) + lo));
+        var lux = ((hi << 8) + lo)/1.2;
+        if (self.options.command = 0x11) {
+            lux = lux/2;
+        }
+        cb.call(self, lux);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "bh1750",
+    "name": "bh1750-jh",
     "description": "light sensor bh1750 with raspberry pi",
-    "author": "Miroslav Rúčka",
-    "version": "0.0.2",
+    "author": "Miroslav Rúčka, Jos Hendriks",
+    "version": "0.0.1",
     "main": "bh1750",
     "repository": {
         "type": "git",
-        "url": "https://github.com/miroRucka/bh1750"
+        "url": "https://github.com/circuitdb/bh1750"
     },
     "dependencies": {
         "lodash": "2.4.1",


### PR DESCRIPTION
Hi, 

I made the following changes to return the measurement in lux 
- Divide by 1.2 as described in BH1750 datasheet.
- Divide by 2 when in high-resolution mode2 as described in BH1750 datasheet.

Can you please review and publish this to npm?

Thanks!