### PR TITLE
Trap errors using callbacks and disable verbose

### DIFF
--- a/bh1750.js
+++ b/bh1750.js
@@ -9,6 +9,7 @@ var BH1750 = function (opts) {
         command: 0x10,
         length: 2
     }, opts);
+    this.verbose = this.options.verbose || false;
     this.wire = new i2c(this.options.address, {device: this.options.device});
 };
 
@@ -19,7 +20,8 @@ BH1750.prototype.readLight = function (cb) {
     }
     self.wire.readBytes(self.options.command, self.options.length, function (err, res) {
         if (utils.exists(err)) {
-            console.error("error: I/O failure on BH1750 - command: ", self.options.command);
+            if (self.verbose)
+                console.error("error: I/O failure on BH1750 - command: ", self.options.command);
             return cb(err, null);
         }
         var hi = res.readUInt8(0);

--- a/bh1750.js
+++ b/bh1750.js
@@ -20,7 +20,7 @@ BH1750.prototype.readLight = function (cb) {
     self.wire.readBytes(self.options.command, self.options.length, function (err, res) {
         if (utils.exists(err)) {
             console.error("error: I/O failure on BH1750 - command: ", self.options.command);
-            return;
+            return cb(err, null);
         }
         var hi = res.readUInt8(0);
         var lo = res.readUInt8(1);
@@ -28,7 +28,7 @@ BH1750.prototype.readLight = function (cb) {
         if (self.options.command = 0x11) {
             lux = lux/2;
         }
-        cb.call(self, lux);
+        cb(null, lux);
     });
 };
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,10 +1,11 @@
 var BH1750 = require('../bh1750');
 var light = new BH1750();
 
-light.readLight(function(value){
-    console.log("light value is: ", value, "lx");
+light.readLight(function(err, value){
+    if (err) {
+        console.log("light error: " + err);
+        throw err;
+    } else {
+        console.log("light value is: ", value, "lx");
+    }
 });
-
-
-
-


### PR DESCRIPTION
If device is not present expect it to be reported as:

  node example
  light error: Error: Error reading length of bytes

Change-Id: Ied017760fd57d1995a97d35f1d434b13d35075a3
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>