### PR TITLE
npm: Update version to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-    "name": "bh1750-jh",
+    "name": "bh1750",
     "description": "light sensor bh1750 with raspberry pi",
     "author": "Miroslav Rúčka, Jos Hendriks",
-    "version": "0.0.1",
+    "version": "0.0.4",
     "main": "bh1750",
     "scripts": {
         "test": "node example"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/circuitdb/bh1750"
+        "url": "https://github.com/miroRucka/bh1750"
     },
     "dependencies": {
         "lodash": "2.4.1",


### PR DESCRIPTION
I assume it will be published at:
https://www.npmjs.com/package/bh1750

Then it could supersede bh1750-jh (git less project):
https://www.npmjs.com/package/bh1750-jh

Change-Id: Ieac58999415b623429134344d43268b772fc07b2
Signed-off-by: Philippe Coval <p.coval@samsung.com>