### PR TITLE
command: Fix comparaison of command (== 0x11) for half lx

### DIFF
--- a/bh1750.js
+++ b/bh1750.js
@@ -27,7 +27,7 @@ BH1750.prototype.readLight = function (cb) {
         var hi = res.readUInt8(0);
         var lo = res.readUInt8(1);
         var lux = ((hi << 8) + lo)/1.2;
-        if (self.options.command = 0x11) {
+        if (self.options.command === 0x11) {
             lux = lux/2;
         }
         cb(null, lux);


### PR DESCRIPTION
I assume  author @circuitdb wanted this in:
https://github.com/miroRucka/bh1750/pull/3

Change-Id: Ic8666c0b735a970f0ff82fedc4e654969a1a0076
Signed-off-by: Philippe Coval <p.coval@samsung.com>