### PR TITLE
npm: Support node-10 with abandonware i2c

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/miroRucka/bh1750"
   },
   "dependencies": {
-    "i2c": "~0.2.1"
+    "@abandonware/i2c": "^0.2.4-0"
   },
   "keywords": [
     "raspberry, raspberry pi, light, sensor, bh1750, ambient-light, iotjs-module"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "eslint": "^5.4.0"
-  }
+  },
   "iotjs": {
     "version": ">=1.0"
   }


### PR DESCRIPTION
Bug: https://github.com/miroRucka/bh1750/issues/22
Change-Id: Ic77764ba2a71119394988cb0035bbeb521c65b1a
Signed-off-by: Philippe Coval <p.coval@samsung.com>